### PR TITLE
yandex speech to text parser

### DIFF
--- a/libs/langchain/langchain/document_loaders/parsers/audio.py
+++ b/libs/langchain/langchain/document_loaders/parsers/audio.py
@@ -227,11 +227,31 @@ class YandexSTTParser(BaseBlobParser):
 
     def __init__(
         self,
+        *,
         api_key: Optional[str] = None,
+        iam_token: Optional[str] = None,
         model: str = "general",
         language: str = "auto",
     ):
+        """Initialize the parser.
+
+        Args:
+            api_key: API key for a service account
+            with the `ai.speechkit-stt.user` role.
+            iam_token: IAM token for a service account
+            with the `ai.speechkit-stt.user` role.
+            model: Recognition model name.
+              Defaults to general.
+            language: The language in ISO 639-1 format.
+              Defaults to automatic language recognition.
+        Either `api_key` or `iam_token` must be provided, but not both.
+        """
+        if (api_key is None) == (iam_token is None):
+            raise ValueError(
+                "Either 'api_key' or 'iam_token' must be provided, but not both."
+            )
         self.api_key = api_key
+        self.iam_token = iam_token
         self.model = model
         self.language = language
 
@@ -256,6 +276,10 @@ class YandexSTTParser(BaseBlobParser):
         if self.api_key:
             configure_credentials(
                 yandex_credentials=creds.YandexCredentials(api_key=self.api_key)
+            )
+        else:
+            configure_credentials(
+                yandex_credentials=creds.YandexCredentials(iam_token=self.iam_token)
             )
 
         audio = AudioSegment.from_file(blob.path)

--- a/libs/langchain/langchain/document_loaders/parsers/audio.py
+++ b/libs/langchain/langchain/document_loaders/parsers/audio.py
@@ -239,9 +239,8 @@ class YandexSTTParser(BaseBlobParser):
         """Lazily parse the blob."""
 
         try:
-            from speechkit import model_repository
+            from speechkit import configure_credentials, creds, model_repository
             from speechkit.stt import AudioProcessingType
-            from speechkit import configure_credentials, creds
         except ImportError:
             raise ImportError(
                 "yandex-speechkit package not found, please install it with "


### PR DESCRIPTION
Пример использования
```python
from langchain.document_loaders.parsers.audio import YandexSTTParser
from langchain.document_loaders.generic import GenericLoader
import os

loader = GenericLoader.from_filesystem(
    path=".",
    glob="speech.mp3",
    parser=YandexSTTParser(api_key=os.getenv("API_KEY")
)

print(loader.load())
```
```
[Document(page_content='недавнее и неприемлемое северокорейское ядерные испытания только что напомнила нам увы актуальной проблемы распространения', metadata={'source': 'speech.mp3'})]
```